### PR TITLE
Changes rule 'arrow-body-style' to error

### DIFF
--- a/rules/es6.js
+++ b/rules/es6.js
@@ -12,9 +12,7 @@ module.exports = {
     },
     rules: {
         // require braces around arrow function bodies
-        'arrow-body-style': ['error', 'as-needed', {
-            requireReturnForObjectLiteral: false,
-        }],
+        'arrow-body-style': ['error', 'always'],
 
         // require parentheses around arrow function arguments
         'arrow-parens': ['error', 'as-needed', {


### PR DESCRIPTION
Changes the rule 'arrow-body-style' from 'as-needed' to 'always'
to ensure a better legibility in the code. Javascript code gets
compiled and minifed by buildtools like webpack e.g.i

With the rule 'as-needed' code is correctly written like this:
```
myArray.map(item => myFunction(item));
```

To force a better legibility the code should be written like this:
```
myArray.map((item) => {
     return myFunction(item);
 });
```